### PR TITLE
Fix Interrupt example

### DIFF
--- a/libraries/LoRa/examples/LoRaWAN/LoRaWan_interrupt/LoRaWan_interrupt.ino
+++ b/libraries/LoRa/examples/LoRaWAN/LoRaWan_interrupt/LoRaWan_interrupt.ino
@@ -27,6 +27,7 @@ LoRaMacRegion_t loraWanRegion = ACTIVE_REGION;
 DeviceClass_t  loraWanClass = LORAWAN_CLASS;
 
 /*the application data transmission duty cycle.  value in [ms].*/
+/*For this example, this is the frequency of the device status packets */
 uint32_t appTxDutyCycle = (24 * 60 * 60 * 1000); // 24h;
 
 /*OTAA or ABP*/
@@ -72,12 +73,12 @@ static bool prepareTxFrame( uint8_t port )
   int head;
   appPort = port;
   switch (port) {
-    case 1: // woke up from interrupt
+    case APPPORT: // woke up from interrupt
       Serial.println("Sending data packet");
       appDataSize = 1;//AppDataSize max value is 64
       appData[0] = 0xFF; // set to something useful  
       break;
-    case 2: // daily wake up
+    case DEVPORT: // daily wake up
       Serial.println("Sending dev status packet");
       appDataSize = 1;//AppDataSize max value is 64
       appData[0] = 0xA0; // set to something else useful
@@ -136,7 +137,7 @@ void loop()
     }
     case DEVICE_STATE_SEND:
     {
-      prepareTxFrame( appPort );
+      prepareTxFrame( DEVPORT );
       LoRaWAN.send();
       deviceState = DEVICE_STATE_CYCLE;
       break;

--- a/libraries/SoftwareSerial/PWM1.h
+++ b/libraries/SoftwareSerial/PWM1.h
@@ -1,0 +1,583 @@
+/*******************************************************************************
+* File Name: PWM1.h
+* Version 2.10
+*
+* Description:
+*  This file provides constants and parameter values for the PWM1
+*  component.
+*
+* Note:
+*  None
+*
+********************************************************************************
+* Copyright 2013-2015, Cypress Semiconductor Corporation.  All rights reserved.
+* You may use this file only in accordance with the license, terms, conditions,
+* disclaimers, and limitations in the end user license agreement accompanying
+* the software package with which this file was provided.
+*******************************************************************************/
+
+#if !defined(CY_TCPWM_PWM1_H)
+#define CY_TCPWM_PWM1_H
+
+
+#include "CyLib.h"
+#include "cytypes.h"
+#include "cyfitter.h"
+
+
+/* PWM1 */
+#define PWM1_cy_m0s8_tcpwm_1__CC CYREG_TCPWM_CNT5_CC
+#define PWM1_cy_m0s8_tcpwm_1__CC_BUFF CYREG_TCPWM_CNT5_CC_BUFF
+#define PWM1_cy_m0s8_tcpwm_1__COUNTER CYREG_TCPWM_CNT5_COUNTER
+#define PWM1_cy_m0s8_tcpwm_1__CTRL CYREG_TCPWM_CNT5_CTRL
+#define PWM1_cy_m0s8_tcpwm_1__INTR CYREG_TCPWM_CNT5_INTR
+#define PWM1_cy_m0s8_tcpwm_1__INTR_MASK CYREG_TCPWM_CNT5_INTR_MASK
+#define PWM1_cy_m0s8_tcpwm_1__INTR_MASKED CYREG_TCPWM_CNT5_INTR_MASKED
+#define PWM1_cy_m0s8_tcpwm_1__INTR_SET CYREG_TCPWM_CNT5_INTR_SET
+#define PWM1_cy_m0s8_tcpwm_1__PERIOD CYREG_TCPWM_CNT5_PERIOD
+#define PWM1_cy_m0s8_tcpwm_1__PERIOD_BUFF CYREG_TCPWM_CNT5_PERIOD_BUFF
+#define PWM1_cy_m0s8_tcpwm_1__STATUS CYREG_TCPWM_CNT5_STATUS
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMD CYREG_TCPWM_CMD
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDCAPTURE_MASK 0x20u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDCAPTURE_SHIFT 5u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDRELOAD_MASK 0x2000u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDRELOAD_SHIFT 13u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDSTART_MASK 0x20000000u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDSTART_SHIFT 29u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDSTOP_MASK 0x200000u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CMDSTOP_SHIFT 21u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL CYREG_TCPWM_CTRL
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL_MASK 0x20u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL_SHIFT 5u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_INTR_CAUSE CYREG_TCPWM_INTR_CAUSE
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_INTR_CAUSE_MASK 0x20u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_INTR_CAUSE_SHIFT 5u
+#define PWM1_cy_m0s8_tcpwm_1__TCPWM_NUMBER 5u
+#define PWM1_cy_m0s8_tcpwm_1__TR_CTRL0 CYREG_TCPWM_CNT5_TR_CTRL0
+#define PWM1_cy_m0s8_tcpwm_1__TR_CTRL1 CYREG_TCPWM_CNT5_TR_CTRL1
+#define PWM1_cy_m0s8_tcpwm_1__TR_CTRL2 CYREG_TCPWM_CNT5_TR_CTRL2    
+
+/* ClockPWM1 */
+#define ClockPWM1__CTRL_REGISTER CYREG_PERI_PCLK_CTL11
+#define ClockPWM1__DIV_ID 0x00000041u
+#define ClockPWM1__DIV_REGISTER CYREG_PERI_DIV_16_CTL1
+#define ClockPWM1__PA_DIV_ID 0x000000FFu    
+    
+    
+/*******************************************************************************
+* Internal Type defines
+*******************************************************************************/
+
+/* Structure to save state before go to sleep */
+typedef struct
+{
+    uint8  enableState;
+} PWM1_BACKUP_STRUCT;
+
+
+/*******************************************************************************
+* Variables
+*******************************************************************************/
+extern uint8  PWM1_initVar;
+
+
+/***************************************
+*   Conditional Compilation Parameters
+****************************************/
+
+#define PWM1_CY_TCPWM_V2                    (CYIPBLOCK_m0s8tcpwm_VERSION == 2u)
+#define PWM1_CY_TCPWM_4000                  (CY_PSOC4_4000)
+
+/* TCPWM Configuration */
+#define PWM1_CONFIG                         (7lu)
+
+/* Quad Mode */
+/* Parameters */
+#define PWM1_QUAD_ENCODING_MODES            (0lu)
+#define PWM1_QUAD_AUTO_START                (0lu)
+
+/* Signal modes */
+#define PWM1_QUAD_INDEX_SIGNAL_MODE         (0lu)
+#define PWM1_QUAD_PHIA_SIGNAL_MODE          (3lu)
+#define PWM1_QUAD_PHIB_SIGNAL_MODE          (3lu)
+#define PWM1_QUAD_STOP_SIGNAL_MODE          (0lu)
+
+/* Signal present */
+#define PWM1_QUAD_INDEX_SIGNAL_PRESENT      (0lu)
+#define PWM1_QUAD_STOP_SIGNAL_PRESENT       (0lu)
+
+/* Interrupt Mask */
+#define PWM1_QUAD_INTERRUPT_MASK            (1lu)
+
+/* Timer/Counter Mode */
+/* Parameters */
+#define PWM1_TC_RUN_MODE                    (0lu)
+#define PWM1_TC_COUNTER_MODE                (0lu)
+#define PWM1_TC_COMP_CAP_MODE               (2lu)
+#define PWM1_TC_PRESCALER                   (0lu)
+
+/* Signal modes */
+#define PWM1_TC_RELOAD_SIGNAL_MODE          (0lu)
+#define PWM1_TC_COUNT_SIGNAL_MODE           (3lu)
+#define PWM1_TC_START_SIGNAL_MODE           (0lu)
+#define PWM1_TC_STOP_SIGNAL_MODE            (0lu)
+#define PWM1_TC_CAPTURE_SIGNAL_MODE         (0lu)
+
+/* Signal present */
+#define PWM1_TC_RELOAD_SIGNAL_PRESENT       (0lu)
+#define PWM1_TC_COUNT_SIGNAL_PRESENT        (0lu)
+#define PWM1_TC_START_SIGNAL_PRESENT        (0lu)
+#define PWM1_TC_STOP_SIGNAL_PRESENT         (0lu)
+#define PWM1_TC_CAPTURE_SIGNAL_PRESENT      (0lu)
+
+/* Interrupt Mask */
+#define PWM1_TC_INTERRUPT_MASK              (1lu)
+
+/* PWM Mode */
+/* Parameters */
+#define PWM1_PWM_KILL_EVENT                 (0lu)
+#define PWM1_PWM_STOP_EVENT                 (0lu)
+#define PWM1_PWM_MODE                       (4lu)
+#define PWM1_PWM_OUT_N_INVERT               (0lu)
+#define PWM1_PWM_OUT_INVERT                 (0lu)
+#define PWM1_PWM_ALIGN                      (0lu)
+#define PWM1_PWM_RUN_MODE                   (0lu)
+#define PWM1_PWM_DEAD_TIME_CYCLE            (0lu)
+#define PWM1_PWM_PRESCALER                  (0lu)
+
+/* Signal modes */
+#define PWM1_PWM_RELOAD_SIGNAL_MODE         (0lu)
+#define PWM1_PWM_COUNT_SIGNAL_MODE          (3lu)
+#define PWM1_PWM_START_SIGNAL_MODE          (0lu)
+#define PWM1_PWM_STOP_SIGNAL_MODE           (0lu)
+#define PWM1_PWM_SWITCH_SIGNAL_MODE         (0lu)
+
+/* Signal present */
+#define PWM1_PWM_RELOAD_SIGNAL_PRESENT      (0lu)
+#define PWM1_PWM_COUNT_SIGNAL_PRESENT       (0lu)
+#define PWM1_PWM_START_SIGNAL_PRESENT       (0lu)
+#define PWM1_PWM_STOP_SIGNAL_PRESENT        (0lu)
+#define PWM1_PWM_SWITCH_SIGNAL_PRESENT      (0lu)
+
+/* Interrupt Mask */
+#define PWM1_PWM_INTERRUPT_MASK             (1lu)
+
+
+/***************************************
+*    Initial Parameter Constants
+***************************************/
+
+/* Timer/Counter Mode */
+#define PWM1_TC_PERIOD_VALUE                (65535lu)
+#define PWM1_TC_COMPARE_VALUE               (65535lu)
+#define PWM1_TC_COMPARE_BUF_VALUE           (65535lu)
+#define PWM1_TC_COMPARE_SWAP                (0lu)
+
+/* PWM Mode */
+#define PWM1_PWM_PERIOD_VALUE               (63000lu)
+#define PWM1_PWM_PERIOD_BUF_VALUE           (65535lu)
+#define PWM1_PWM_PERIOD_SWAP                (0lu)
+#define PWM1_PWM_COMPARE_VALUE              (0lu)
+#define PWM1_PWM_COMPARE_BUF_VALUE          (65535lu)
+#define PWM1_PWM_COMPARE_SWAP               (0lu)
+
+
+/***************************************
+*    Enumerated Types and Parameters
+***************************************/
+
+#define PWM1__LEFT 0
+#define PWM1__RIGHT 1
+#define PWM1__CENTER 2
+#define PWM1__ASYMMETRIC 3
+
+#define PWM1__X1 0
+#define PWM1__X2 1
+#define PWM1__X4 2
+
+#define PWM1__PWM 4
+#define PWM1__PWM_DT 5
+#define PWM1__PWM_PR 6
+
+#define PWM1__INVERSE 1
+#define PWM1__DIRECT 0
+
+#define PWM1__CAPTURE 2
+#define PWM1__COMPARE 0
+
+#define PWM1__TRIG_LEVEL 3
+#define PWM1__TRIG_RISING 0
+#define PWM1__TRIG_FALLING 1
+#define PWM1__TRIG_BOTH 2
+
+#define PWM1__INTR_MASK_TC 1
+#define PWM1__INTR_MASK_CC_MATCH 2
+#define PWM1__INTR_MASK_NONE 0
+#define PWM1__INTR_MASK_TC_CC 3
+
+#define PWM1__UNCONFIG 8
+#define PWM1__TIMER 1
+#define PWM1__QUAD 3
+#define PWM1__PWM_SEL 7
+
+#define PWM1__COUNT_UP 0
+#define PWM1__COUNT_DOWN 1
+#define PWM1__COUNT_UPDOWN0 2
+#define PWM1__COUNT_UPDOWN1 3
+
+
+/* Prescaler */
+#define PWM1_PRESCALE_DIVBY1                ((uint32)(0u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY2                ((uint32)(1u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY4                ((uint32)(2u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY8                ((uint32)(3u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY16               ((uint32)(4u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY32               ((uint32)(5u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY64               ((uint32)(6u << PWM1_PRESCALER_SHIFT))
+#define PWM1_PRESCALE_DIVBY128              ((uint32)(7u << PWM1_PRESCALER_SHIFT))
+
+/* TCPWM set modes */
+#define PWM1_MODE_TIMER_COMPARE             ((uint32)(PWM1__COMPARE         <<  \
+                                                                  PWM1_MODE_SHIFT))
+#define PWM1_MODE_TIMER_CAPTURE             ((uint32)(PWM1__CAPTURE         <<  \
+                                                                  PWM1_MODE_SHIFT))
+#define PWM1_MODE_QUAD                      ((uint32)(PWM1__QUAD            <<  \
+                                                                  PWM1_MODE_SHIFT))
+#define PWM1_MODE_PWM                       ((uint32)(PWM1__PWM             <<  \
+                                                                  PWM1_MODE_SHIFT))
+#define PWM1_MODE_PWM_DT                    ((uint32)(PWM1__PWM_DT          <<  \
+                                                                  PWM1_MODE_SHIFT))
+#define PWM1_MODE_PWM_PR                    ((uint32)(PWM1__PWM_PR          <<  \
+                                                                  PWM1_MODE_SHIFT))
+
+/* Quad Modes */
+#define PWM1_MODE_X1                        ((uint32)(PWM1__X1              <<  \
+                                                                  PWM1_QUAD_MODE_SHIFT))
+#define PWM1_MODE_X2                        ((uint32)(PWM1__X2              <<  \
+                                                                  PWM1_QUAD_MODE_SHIFT))
+#define PWM1_MODE_X4                        ((uint32)(PWM1__X4              <<  \
+                                                                  PWM1_QUAD_MODE_SHIFT))
+
+/* Counter modes */
+#define PWM1_COUNT_UP                       ((uint32)(PWM1__COUNT_UP        <<  \
+                                                                  PWM1_UPDOWN_SHIFT))
+#define PWM1_COUNT_DOWN                     ((uint32)(PWM1__COUNT_DOWN      <<  \
+                                                                  PWM1_UPDOWN_SHIFT))
+#define PWM1_COUNT_UPDOWN0                  ((uint32)(PWM1__COUNT_UPDOWN0   <<  \
+                                                                  PWM1_UPDOWN_SHIFT))
+#define PWM1_COUNT_UPDOWN1                  ((uint32)(PWM1__COUNT_UPDOWN1   <<  \
+                                                                  PWM1_UPDOWN_SHIFT))
+
+/* PWM output invert */
+#define PWM1_INVERT_LINE                    ((uint32)(PWM1__INVERSE         <<  \
+                                                                  PWM1_INV_OUT_SHIFT))
+#define PWM1_INVERT_LINE_N                  ((uint32)(PWM1__INVERSE         <<  \
+                                                                  PWM1_INV_COMPL_OUT_SHIFT))
+
+/* Trigger modes */
+#define PWM1_TRIG_RISING                    ((uint32)PWM1__TRIG_RISING)
+#define PWM1_TRIG_FALLING                   ((uint32)PWM1__TRIG_FALLING)
+#define PWM1_TRIG_BOTH                      ((uint32)PWM1__TRIG_BOTH)
+#define PWM1_TRIG_LEVEL                     ((uint32)PWM1__TRIG_LEVEL)
+
+/* Interrupt mask */
+#define PWM1_INTR_MASK_TC                   ((uint32)PWM1__INTR_MASK_TC)
+#define PWM1_INTR_MASK_CC_MATCH             ((uint32)PWM1__INTR_MASK_CC_MATCH)
+
+/* PWM Output Controls */
+#define PWM1_CC_MATCH_SET                   (0x00u)
+#define PWM1_CC_MATCH_CLEAR                 (0x01u)
+#define PWM1_CC_MATCH_INVERT                (0x02u)
+#define PWM1_CC_MATCH_NO_CHANGE             (0x03u)
+#define PWM1_OVERLOW_SET                    (0x00u)
+#define PWM1_OVERLOW_CLEAR                  (0x04u)
+#define PWM1_OVERLOW_INVERT                 (0x08u)
+#define PWM1_OVERLOW_NO_CHANGE              (0x0Cu)
+#define PWM1_UNDERFLOW_SET                  (0x00u)
+#define PWM1_UNDERFLOW_CLEAR                (0x10u)
+#define PWM1_UNDERFLOW_INVERT               (0x20u)
+#define PWM1_UNDERFLOW_NO_CHANGE            (0x30u)
+
+/* PWM Align */
+#define PWM1_PWM_MODE_LEFT                  (PWM1_CC_MATCH_CLEAR        |   \
+                                                         PWM1_OVERLOW_SET           |   \
+                                                         PWM1_UNDERFLOW_NO_CHANGE)
+#define PWM1_PWM_MODE_RIGHT                 (PWM1_CC_MATCH_SET          |   \
+                                                         PWM1_OVERLOW_NO_CHANGE     |   \
+                                                         PWM1_UNDERFLOW_CLEAR)
+#define PWM1_PWM_MODE_ASYM                  (PWM1_CC_MATCH_INVERT       |   \
+                                                         PWM1_OVERLOW_SET           |   \
+                                                         PWM1_UNDERFLOW_CLEAR)
+
+#if (PWM1_CY_TCPWM_V2)
+    #if(PWM1_CY_TCPWM_4000)
+        #define PWM1_PWM_MODE_CENTER                (PWM1_CC_MATCH_INVERT       |   \
+                                                                 PWM1_OVERLOW_NO_CHANGE     |   \
+                                                                 PWM1_UNDERFLOW_CLEAR)
+    #else
+        #define PWM1_PWM_MODE_CENTER                (PWM1_CC_MATCH_INVERT       |   \
+                                                                 PWM1_OVERLOW_SET           |   \
+                                                                 PWM1_UNDERFLOW_CLEAR)
+    #endif /* (PWM1_CY_TCPWM_4000) */
+#else
+    #define PWM1_PWM_MODE_CENTER                (PWM1_CC_MATCH_INVERT       |   \
+                                                             PWM1_OVERLOW_NO_CHANGE     |   \
+                                                             PWM1_UNDERFLOW_CLEAR)
+#endif /* (PWM1_CY_TCPWM_NEW) */
+
+/* Command operations without condition */
+#define PWM1_CMD_CAPTURE                    (0u)
+#define PWM1_CMD_RELOAD                     (8u)
+#define PWM1_CMD_STOP                       (16u)
+#define PWM1_CMD_START                      (24u)
+
+/* Status */
+#define PWM1_STATUS_DOWN                    (1u)
+#define PWM1_STATUS_RUNNING                 (2u)
+
+
+/***************************************
+*        Function Prototypes
+****************************************/
+
+void   PWM1_Init(void);
+void   PWM1_Enable(void);
+void   PWM1_Start(void);
+void   PWM1_Stop(void);
+
+void   PWM1_SetMode(uint32 mode);
+void   PWM1_SetCounterMode(uint32 counterMode);
+void   PWM1_SetPWMMode(uint32 modeMask);
+void   PWM1_SetQDMode(uint32 qdMode);
+
+void   PWM1_SetPrescaler(uint32 prescaler);
+void   PWM1_TriggerCommand(uint32 mask, uint32 command);
+void   PWM1_SetOneShot(uint32 oneShotEnable);
+uint32 PWM1_ReadStatus(void);
+
+void   PWM1_SetPWMSyncKill(uint32 syncKillEnable);
+void   PWM1_SetPWMStopOnKill(uint32 stopOnKillEnable);
+void   PWM1_SetPWMDeadTime(uint32 deadTime);
+void   PWM1_SetPWMInvert(uint32 mask);
+
+void   PWM1_SetInterruptMode(uint32 interruptMask);
+uint32 PWM1_GetInterruptSourceMasked(void);
+uint32 PWM1_GetInterruptSource(void);
+void   PWM1_ClearInterrupt(uint32 interruptMask);
+void   PWM1_SetInterrupt(uint32 interruptMask);
+
+void   PWM1_WriteCounter(uint32 count);
+uint32 PWM1_ReadCounter(void);
+
+uint32 PWM1_ReadCapture(void);
+uint32 PWM1_ReadCaptureBuf(void);
+
+void   PWM1_WritePeriod(uint32 period);
+uint32 PWM1_ReadPeriod(void);
+void   PWM1_WritePeriodBuf(uint32 periodBuf);
+uint32 PWM1_ReadPeriodBuf(void);
+
+void   PWM1_WriteCompare(uint32 compare);
+uint32 PWM1_ReadCompare(void);
+void   PWM1_WriteCompareBuf(uint32 compareBuf);
+uint32 PWM1_ReadCompareBuf(void);
+
+void   PWM1_SetPeriodSwap(uint32 swapEnable);
+void   PWM1_SetCompareSwap(uint32 swapEnable);
+
+void   PWM1_SetCaptureMode(uint32 triggerMode);
+void   PWM1_SetReloadMode(uint32 triggerMode);
+void   PWM1_SetStartMode(uint32 triggerMode);
+void   PWM1_SetStopMode(uint32 triggerMode);
+void   PWM1_SetCountMode(uint32 triggerMode);
+
+void   PWM1_SaveConfig(void);
+void   PWM1_RestoreConfig(void);
+void   PWM1_Sleep(void);
+void   PWM1_Wakeup(void);
+
+
+/***************************************
+*             Registers
+***************************************/
+
+#define PWM1_BLOCK_CONTROL_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL )
+#define PWM1_BLOCK_CONTROL_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL )
+#define PWM1_COMMAND_REG                    (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_CMD )
+#define PWM1_COMMAND_PTR                    ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_CMD )
+#define PWM1_INTRRUPT_CAUSE_REG             (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_INTR_CAUSE )
+#define PWM1_INTRRUPT_CAUSE_PTR             ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TCPWM_INTR_CAUSE )
+#define PWM1_CONTROL_REG                    (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__CTRL )
+#define PWM1_CONTROL_PTR                    ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__CTRL )
+#define PWM1_STATUS_REG                     (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__STATUS )
+#define PWM1_STATUS_PTR                     ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__STATUS )
+#define PWM1_COUNTER_REG                    (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__COUNTER )
+#define PWM1_COUNTER_PTR                    ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__COUNTER )
+#define PWM1_COMP_CAP_REG                   (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__CC )
+#define PWM1_COMP_CAP_PTR                   ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__CC )
+#define PWM1_COMP_CAP_BUF_REG               (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__CC_BUFF )
+#define PWM1_COMP_CAP_BUF_PTR               ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__CC_BUFF )
+#define PWM1_PERIOD_REG                     (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__PERIOD )
+#define PWM1_PERIOD_PTR                     ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__PERIOD )
+#define PWM1_PERIOD_BUF_REG                 (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__PERIOD_BUFF )
+#define PWM1_PERIOD_BUF_PTR                 ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__PERIOD_BUFF )
+#define PWM1_TRIG_CONTROL0_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL0 )
+#define PWM1_TRIG_CONTROL0_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL0 )
+#define PWM1_TRIG_CONTROL1_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL1 )
+#define PWM1_TRIG_CONTROL1_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL1 )
+#define PWM1_TRIG_CONTROL2_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL2 )
+#define PWM1_TRIG_CONTROL2_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__TR_CTRL2 )
+#define PWM1_INTERRUPT_REQ_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR )
+#define PWM1_INTERRUPT_REQ_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR )
+#define PWM1_INTERRUPT_SET_REG              (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_SET )
+#define PWM1_INTERRUPT_SET_PTR              ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_SET )
+#define PWM1_INTERRUPT_MASK_REG             (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_MASK )
+#define PWM1_INTERRUPT_MASK_PTR             ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_MASK )
+#define PWM1_INTERRUPT_MASKED_REG           (*(reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_MASKED )
+#define PWM1_INTERRUPT_MASKED_PTR           ( (reg32 *) PWM1_cy_m0s8_tcpwm_1__INTR_MASKED )
+
+
+/***************************************
+*       Registers Constants
+***************************************/
+
+/* Mask */
+#define PWM1_MASK                           ((uint32)PWM1_cy_m0s8_tcpwm_1__TCPWM_CTRL_MASK)
+
+/* Shift constants for control register */
+#define PWM1_RELOAD_CC_SHIFT                (0u)
+#define PWM1_RELOAD_PERIOD_SHIFT            (1u)
+#define PWM1_PWM_SYNC_KILL_SHIFT            (2u)
+#define PWM1_PWM_STOP_KILL_SHIFT            (3u)
+#define PWM1_PRESCALER_SHIFT                (8u)
+#define PWM1_UPDOWN_SHIFT                   (16u)
+#define PWM1_ONESHOT_SHIFT                  (18u)
+#define PWM1_QUAD_MODE_SHIFT                (20u)
+#define PWM1_INV_OUT_SHIFT                  (20u)
+#define PWM1_INV_COMPL_OUT_SHIFT            (21u)
+#define PWM1_MODE_SHIFT                     (24u)
+
+/* Mask constants for control register */
+#define PWM1_RELOAD_CC_MASK                 ((uint32)(PWM1_1BIT_MASK        <<  \
+                                                                            PWM1_RELOAD_CC_SHIFT))
+#define PWM1_RELOAD_PERIOD_MASK             ((uint32)(PWM1_1BIT_MASK        <<  \
+                                                                            PWM1_RELOAD_PERIOD_SHIFT))
+#define PWM1_PWM_SYNC_KILL_MASK             ((uint32)(PWM1_1BIT_MASK        <<  \
+                                                                            PWM1_PWM_SYNC_KILL_SHIFT))
+#define PWM1_PWM_STOP_KILL_MASK             ((uint32)(PWM1_1BIT_MASK        <<  \
+                                                                            PWM1_PWM_STOP_KILL_SHIFT))
+#define PWM1_PRESCALER_MASK                 ((uint32)(PWM1_8BIT_MASK        <<  \
+                                                                            PWM1_PRESCALER_SHIFT))
+#define PWM1_UPDOWN_MASK                    ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                            PWM1_UPDOWN_SHIFT))
+#define PWM1_ONESHOT_MASK                   ((uint32)(PWM1_1BIT_MASK        <<  \
+                                                                            PWM1_ONESHOT_SHIFT))
+#define PWM1_QUAD_MODE_MASK                 ((uint32)(PWM1_3BIT_MASK        <<  \
+                                                                            PWM1_QUAD_MODE_SHIFT))
+#define PWM1_INV_OUT_MASK                   ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                            PWM1_INV_OUT_SHIFT))
+#define PWM1_MODE_MASK                      ((uint32)(PWM1_3BIT_MASK        <<  \
+                                                                            PWM1_MODE_SHIFT))
+
+/* Shift constants for trigger control register 1 */
+#define PWM1_CAPTURE_SHIFT                  (0u)
+#define PWM1_COUNT_SHIFT                    (2u)
+#define PWM1_RELOAD_SHIFT                   (4u)
+#define PWM1_STOP_SHIFT                     (6u)
+#define PWM1_START_SHIFT                    (8u)
+
+/* Mask constants for trigger control register 1 */
+#define PWM1_CAPTURE_MASK                   ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                  PWM1_CAPTURE_SHIFT))
+#define PWM1_COUNT_MASK                     ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                  PWM1_COUNT_SHIFT))
+#define PWM1_RELOAD_MASK                    ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                  PWM1_RELOAD_SHIFT))
+#define PWM1_STOP_MASK                      ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                  PWM1_STOP_SHIFT))
+#define PWM1_START_MASK                     ((uint32)(PWM1_2BIT_MASK        <<  \
+                                                                  PWM1_START_SHIFT))
+
+/* MASK */
+#define PWM1_1BIT_MASK                      ((uint32)0x01u)
+#define PWM1_2BIT_MASK                      ((uint32)0x03u)
+#define PWM1_3BIT_MASK                      ((uint32)0x07u)
+#define PWM1_6BIT_MASK                      ((uint32)0x3Fu)
+#define PWM1_8BIT_MASK                      ((uint32)0xFFu)
+#define PWM1_16BIT_MASK                     ((uint32)0xFFFFu)
+
+/* Shift constant for status register */
+#define PWM1_RUNNING_STATUS_SHIFT           (30u)
+
+
+/***************************************
+*    Initial Constants
+***************************************/
+
+#define PWM1_CTRL_QUAD_BASE_CONFIG                                                          \
+        (((uint32)(PWM1_QUAD_ENCODING_MODES     << PWM1_QUAD_MODE_SHIFT))       |\
+         ((uint32)(PWM1_CONFIG                  << PWM1_MODE_SHIFT)))
+
+#define PWM1_CTRL_PWM_BASE_CONFIG                                                           \
+        (((uint32)(PWM1_PWM_STOP_EVENT          << PWM1_PWM_STOP_KILL_SHIFT))   |\
+         ((uint32)(PWM1_PWM_OUT_INVERT          << PWM1_INV_OUT_SHIFT))         |\
+         ((uint32)(PWM1_PWM_OUT_N_INVERT        << PWM1_INV_COMPL_OUT_SHIFT))   |\
+         ((uint32)(PWM1_PWM_MODE                << PWM1_MODE_SHIFT)))
+
+#define PWM1_CTRL_PWM_RUN_MODE                                                              \
+            ((uint32)(PWM1_PWM_RUN_MODE         << PWM1_ONESHOT_SHIFT))
+            
+#define PWM1_CTRL_PWM_ALIGN                                                                 \
+            ((uint32)(PWM1_PWM_ALIGN            << PWM1_UPDOWN_SHIFT))
+
+#define PWM1_CTRL_PWM_KILL_EVENT                                                            \
+             ((uint32)(PWM1_PWM_KILL_EVENT      << PWM1_PWM_SYNC_KILL_SHIFT))
+
+#define PWM1_CTRL_PWM_DEAD_TIME_CYCLE                                                       \
+            ((uint32)(PWM1_PWM_DEAD_TIME_CYCLE  << PWM1_PRESCALER_SHIFT))
+
+#define PWM1_CTRL_PWM_PRESCALER                                                             \
+            ((uint32)(PWM1_PWM_PRESCALER        << PWM1_PRESCALER_SHIFT))
+
+#define PWM1_CTRL_TIMER_BASE_CONFIG                                                         \
+        (((uint32)(PWM1_TC_PRESCALER            << PWM1_PRESCALER_SHIFT))       |\
+         ((uint32)(PWM1_TC_COUNTER_MODE         << PWM1_UPDOWN_SHIFT))          |\
+         ((uint32)(PWM1_TC_RUN_MODE             << PWM1_ONESHOT_SHIFT))         |\
+         ((uint32)(PWM1_TC_COMP_CAP_MODE        << PWM1_MODE_SHIFT)))
+        
+#define PWM1_QUAD_SIGNALS_MODES                                                             \
+        (((uint32)(PWM1_QUAD_PHIA_SIGNAL_MODE   << PWM1_COUNT_SHIFT))           |\
+         ((uint32)(PWM1_QUAD_INDEX_SIGNAL_MODE  << PWM1_RELOAD_SHIFT))          |\
+         ((uint32)(PWM1_QUAD_STOP_SIGNAL_MODE   << PWM1_STOP_SHIFT))            |\
+         ((uint32)(PWM1_QUAD_PHIB_SIGNAL_MODE   << PWM1_START_SHIFT)))
+
+#define PWM1_PWM_SIGNALS_MODES                                                              \
+        (((uint32)(PWM1_PWM_SWITCH_SIGNAL_MODE  << PWM1_CAPTURE_SHIFT))         |\
+         ((uint32)(PWM1_PWM_COUNT_SIGNAL_MODE   << PWM1_COUNT_SHIFT))           |\
+         ((uint32)(PWM1_PWM_RELOAD_SIGNAL_MODE  << PWM1_RELOAD_SHIFT))          |\
+         ((uint32)(PWM1_PWM_STOP_SIGNAL_MODE    << PWM1_STOP_SHIFT))            |\
+         ((uint32)(PWM1_PWM_START_SIGNAL_MODE   << PWM1_START_SHIFT)))
+
+#define PWM1_TIMER_SIGNALS_MODES                                                            \
+        (((uint32)(PWM1_TC_CAPTURE_SIGNAL_MODE  << PWM1_CAPTURE_SHIFT))         |\
+         ((uint32)(PWM1_TC_COUNT_SIGNAL_MODE    << PWM1_COUNT_SHIFT))           |\
+         ((uint32)(PWM1_TC_RELOAD_SIGNAL_MODE   << PWM1_RELOAD_SHIFT))          |\
+         ((uint32)(PWM1_TC_STOP_SIGNAL_MODE     << PWM1_STOP_SHIFT))            |\
+         ((uint32)(PWM1_TC_START_SIGNAL_MODE    << PWM1_START_SHIFT)))
+        
+#define PWM1_TIMER_UPDOWN_CNT_USED                                                          \
+                ((PWM1__COUNT_UPDOWN0 == PWM1_TC_COUNTER_MODE)                  ||\
+                 (PWM1__COUNT_UPDOWN1 == PWM1_TC_COUNTER_MODE))
+
+#define PWM1_PWM_UPDOWN_CNT_USED                                                            \
+                ((PWM1__CENTER == PWM1_PWM_ALIGN)                               ||\
+                 (PWM1__ASYMMETRIC == PWM1_PWM_ALIGN))               
+        
+#define PWM1_PWM_PR_INIT_VALUE              (1u)
+#define PWM1_QUAD_PERIOD_INIT_VALUE         (0x8000u)
+
+
+
+#endif /* End CY_TCPWM_PWM1_H */
+
+/* [] END OF FILE */

--- a/libraries/SoftwareSerial/PWM1_ISR.h
+++ b/libraries/SoftwareSerial/PWM1_ISR.h
@@ -1,0 +1,82 @@
+/*******************************************************************************
+* File Name: PWM1_ISR.h
+* Version 1.70
+*
+*  Description:
+*   Provides the function definitions for the Interrupt Controller.
+*
+*
+********************************************************************************
+* Copyright 2008-2015, Cypress Semiconductor Corporation.  All rights reserved.
+* You may use this file only in accordance with the license, terms, conditions, 
+* disclaimers, and limitations in the end user license agreement accompanying 
+* the software package with which this file was provided.
+*******************************************************************************/
+#if !defined(CY_ISR_PWM1_ISR_H)
+#define CY_ISR_PWM1_ISR_H
+    
+
+
+#include <cytypes.h>
+#include <cyfitter.h>
+
+#define PWM1_ISR__INTC_CLR_EN_REG CYREG_CM0P_ICER
+#define PWM1_ISR__INTC_CLR_PD_REG CYREG_CM0P_ICPR
+#define PWM1_ISR__INTC_MASK 0x400000u
+#define PWM1_ISR__INTC_NUMBER 22u
+#define PWM1_ISR__INTC_PRIOR_MASK 0xC00000u
+#define PWM1_ISR__INTC_PRIOR_NUM 3u
+#define PWM1_ISR__INTC_PRIOR_REG CYREG_CM0P_IPR5
+#define PWM1_ISR__INTC_SET_EN_REG CYREG_CM0P_ISER
+#define PWM1_ISR__INTC_SET_PD_REG CYREG_CM0P_ISPR    
+    
+/* Interrupt Controller API. */
+void PWM1_ISR_Start(void);
+void PWM1_ISR_StartEx(cyisraddress address);
+void PWM1_ISR_Stop(void);
+
+CY_ISR_PROTO(PWM1_ISR_Interrupt);
+
+void PWM1_ISR_SetVector(cyisraddress address);
+cyisraddress PWM1_ISR_GetVector(void);
+
+void PWM1_ISR_SetPriority(uint8 priority);
+uint8 PWM1_ISR_GetPriority(void);
+
+void PWM1_ISR_Enable(void);
+uint8 PWM1_ISR_GetState(void);
+void PWM1_ISR_Disable(void);
+
+void PWM1_ISR_SetPending(void);
+void PWM1_ISR_ClearPending(void);
+
+
+/* Interrupt Controller Constants */
+
+/* Address of the INTC.VECT[x] register that contains the Address of the PWM1_ISR ISR. */
+#define PWM1_ISR_INTC_VECTOR            ((reg32 *) PWM1_ISR__INTC_VECT)
+
+/* Address of the PWM1_ISR ISR priority. */
+#define PWM1_ISR_INTC_PRIOR             ((reg32 *) PWM1_ISR__INTC_PRIOR_REG)
+
+/* Priority of the PWM1_ISR interrupt. */
+#define PWM1_ISR_INTC_PRIOR_NUMBER      PWM1_ISR__INTC_PRIOR_NUM
+
+/* Address of the INTC.SET_EN[x] byte to bit enable PWM1_ISR interrupt. */
+#define PWM1_ISR_INTC_SET_EN            ((reg32 *) PWM1_ISR__INTC_SET_EN_REG)
+
+/* Address of the INTC.CLR_EN[x] register to bit clear the PWM1_ISR interrupt. */
+#define PWM1_ISR_INTC_CLR_EN            ((reg32 *) PWM1_ISR__INTC_CLR_EN_REG)
+
+/* Address of the INTC.SET_PD[x] register to set the PWM1_ISR interrupt state to pending. */
+#define PWM1_ISR_INTC_SET_PD            ((reg32 *) PWM1_ISR__INTC_SET_PD_REG)
+
+/* Address of the INTC.CLR_PD[x] register to clear the PWM1_ISR interrupt. */
+#define PWM1_ISR_INTC_CLR_PD            ((reg32 *) PWM1_ISR__INTC_CLR_PD_REG)
+
+
+
+#endif /* CY_ISR_PWM1_ISR_H */
+
+
+/* [] END OF FILE */

--- a/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -1,0 +1,433 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <Arduino.h>
+#include "SoftwareSerial.h"
+#include "PWM1.h"
+
+SoftwareSerial *SoftwareSerial::active_object = 0;
+char SoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF];
+volatile uint32_t SoftwareSerial::_receive_buffer_tail = 0;
+volatile uint32_t SoftwareSerial::_receive_buffer_head = 0;
+
+static uint8 sstate = 0; //
+static uint8 bit = 0; // 0-10
+static uint8 rbyte = 0;
+static int32 waitDelay = 0;
+
+bool SoftwareSerial::listen()
+{
+  if (!_rx_delay_stopbit)
+    return false;
+
+  if (active_object != this) {
+    if (active_object) {
+      active_object->stopListening();
+    }
+
+    _buffer_overflow = false;
+    _receive_buffer_head = _receive_buffer_tail = 0;
+    active_object = this;
+
+    if (_inverse_logic)
+      //Start bit high
+      attachInterrupt(_receivePin, handle_interrupt, RISING);
+    else
+      //Start bit low
+      attachInterrupt(_receivePin, handle_interrupt, FALLING);
+
+    return true;
+  }
+  return false;
+}
+
+bool SoftwareSerial::stopListening() {
+  if (active_object == this) {
+    detachInterrupt(_receivePin);
+    active_object = NULL;
+    return true;
+  }
+  return false;
+}
+
+
+inline void SoftwareSerial::recv() {
+  uint8_t d = 0;
+  uint8_t ints;
+
+  if(sstate > 0) {
+	return; // we're busy in the other handler
+  }
+  // If RX line is high, then we don't see any start bit
+  // so interrupt is probably not for us
+  if (_inverse_logic ? rx_pin_read() : !rx_pin_read()) {
+    ints = CyEnterCriticalSection();
+	sstate = 1; // first bit recv
+        bit = 0;
+        rbyte = 0;
+        waitDelay = _rx_delay_centering;
+        PWM1_BLOCK_CONTROL_REG |= PWM1_MASK; // start the timing interrupt
+           PWM1_COUNTER_REG = (20000 & PWM1_16BIT_MASK);
+            PWM1_PERIOD_REG = (0 & PWM1_16BIT_MASK);
+            PWM1_COMP_CAP_REG = (1001-1 & PWM1_16BIT_MASK);
+
+// adding these made it work again...
+        PWM1_PERIOD_REG = (PWM1_TC_PERIOD_VALUE & PWM1_16BIT_MASK);
+        PWM1_COUNTER_REG = (PWM1_TC_PERIOD_VALUE & PWM1_16BIT_MASK);
+
+    PWM1_BLOCK_CONTROL_REG |= PWM1_MASK;
+(* (reg32 *) CYREG_HSIOM_PORT_SEL6)=((* (reg32 *) CYREG_HSIOM_PORT_SEL6)&(~0x00000800u))|0x00000800u;
+
+    PWM1_CONTROL_REG |= PWM1_MODE_TIMER_COMPARE;
+    PWM1_CONTROL_REG &= (uint32)~PWM1_UPDOWN_MASK;
+    PWM1_CONTROL_REG |= PWM1_COUNT_DOWN;
+    PWM1_COMMAND_REG = (PWM1_MASK << PWM1_CMD_START);
+
+//        Serial.println("Going to other handler");
+     CyExitCriticalSection(ints);
+   }
+  
+}
+
+
+uint32_t SoftwareSerial::rx_pin_read() {
+  return DIRECT_READ(_receiveBase, _receiveBitMask);
+}
+
+/* static */
+inline void SoftwareSerial::handle_interrupt() {
+  if (active_object) {
+    active_object->recv();
+  }
+}
+
+
+// Constructor
+SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic /* = false */) :
+  _rx_delay_centering(0),
+  _rx_delay_intrabit(0),
+  _rx_delay_stopbit(0),
+  _tx_delay(0),
+  _buffer_overflow(false),
+  _inverse_logic(inverse_logic)
+{
+  _receivePin = receivePin;
+  _transmitPin = transmitPin;
+}
+
+// Destructor
+SoftwareSerial::~SoftwareSerial() {
+  end();
+}
+
+void SoftwareSerial::setTX(uint8_t tx) {
+  // First write, then set output. If we do this the other way around,
+  // the pin would be output low for a short while before switching to
+  // output hihg. Now, it is input with pullup for a short while, which
+  // is fine. With inverse logic, either order is fine.
+  pinMode(tx, OUTPUT);
+  _transmitBitMask = PIN_TO_BITMASK(tx);
+  _transmitBase = PIN_TO_BASEREG(tx);
+  _transmitPin = tx;
+}
+
+extern cyisraddress CyRamVectors[CYINT_IRQ_BASE + CY_NUM_INTERRUPTS];
+
+void PWM1_ISR_SetVector(cyisraddress address)
+{
+    CyRamVectors[CYINT_IRQ_BASE + PWM1_ISR__INTC_NUMBER] = address;
+}
+
+void PWM1_SetOneShot(uint32 oneShotEnable)
+{
+    uint8 enableInterrupts;
+
+    enableInterrupts = CyEnterCriticalSection();
+
+    PWM1_CONTROL_REG &= (uint32)~PWM1_ONESHOT_MASK;
+    PWM1_CONTROL_REG |= ((uint32)((oneShotEnable & PWM1_1BIT_MASK) <<
+                                                               PWM1_ONESHOT_SHIFT));
+
+    CyExitCriticalSection(enableInterrupts);
+}
+
+
+void PWM1_ISR_Enable(void)
+{
+    /* Enable the general interrupt. */
+    *PWM1_ISR_INTC_SET_EN = PWM1_ISR__INTC_MASK;
+}
+
+void PWM1_ISR_Disable(void)
+{
+    /* Disable the general interrupt. */
+    *PWM1_ISR_INTC_CLR_EN = PWM1_ISR__INTC_MASK;
+}
+
+void PWM1_ISR_SetPriority(uint8 priority)
+{
+	uint8 interruptState;
+    uint32 priorityOffset = ((PWM1_ISR__INTC_NUMBER % 4u) * 8u) + 6u;
+    
+	interruptState = CyEnterCriticalSection();
+    *PWM1_ISR_INTC_PRIOR = (*PWM1_ISR_INTC_PRIOR & (uint32)(~PWM1_ISR__INTC_PRIOR_MASK)) |
+                                    ((uint32)priority << priorityOffset);
+	CyExitCriticalSection(interruptState);
+}
+
+
+void PWM1_ISR_StartEx(cyisraddress address)
+{
+    /* For all we know the interrupt is active. */
+    PWM1_ISR_Disable();
+
+    /* Set the ISR to point to the PWM1_ISR Interrupt. */
+    PWM1_ISR_SetVector(address);
+
+    /* Set the priority. */
+    PWM1_ISR_SetPriority((uint8)PWM1_ISR_INTC_PRIOR_NUMBER);
+
+    /* Enable it. */
+    PWM1_ISR_Enable();
+}
+
+static uint32 cnt = 0;
+static uint32 last = 0;
+
+CY_ISR(PWM1_ISR_Interrupt)
+{
+    (* (reg32 *) CYREG_HSIOM_PORT_SEL6)=((* (reg32 *) CYREG_HSIOM_PORT_SEL6)&(~0x00000800u));
+
+           PWM1_COUNTER_REG = (20000 & PWM1_16BIT_MASK);
+            PWM1_PERIOD_REG = (0 & PWM1_16BIT_MASK);
+            PWM1_COMP_CAP_REG = (1001-1 & PWM1_16BIT_MASK);
+    PWM1_BLOCK_CONTROL_REG |= PWM1_MASK;
+//    PWM1_CONTROL_REG |= PWM1_MODE_TIMER_COMPARE;
+//    PWM1_CONTROL_REG &= (uint32)~PWM1_UPDOWN_MASK;
+//    PWM1_CONTROL_REG |= PWM1_COUNT_DOWN;
+//    PWM1_COMMAND_REG = (PWM1_MASK << PWM1_CMD_START);
+//    PWM1_BLOCK_CONTROL_REG &= (uint32)~PWM1_MASK;
+
+    uint8 enableInterrupts;
+    if(cnt++ % 100000 == 0) {
+       Serial.printf("state %d, bit %d, waitDelay %d\n", sstate, bit, waitDelay);	
+    }
+    if(sstate == 0) {
+       return;
+    }
+
+    enableInterrupts = CyEnterCriticalSection();
+    if(waitDelay > 0) {
+	waitDelay -= 2; // 2uS
+    } else {
+//     Serial.printf("state2 %d, bit %d, waitDelay %d\n", sstate, bit, waitDelay);
+     rbyte |= (DIRECT_READ(SoftwareSerial::active_object->_receiveBase, SoftwareSerial::active_object->_receiveBitMask) ? 1 : 0) << bit;	
+     //rbyte |= (digialRead(SoftwareSerial::active_object->_receivePin) ? 1 : 0) << bit;
+     bit++;
+     waitDelay = SoftwareSerial::active_object->_rx_delay_intrabit;
+     if(bit == 10) { // 11th bit, so finished
+        // if buffer full, set the overflow flag and return
+        uint32_t next = (SoftwareSerial::active_object->_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
+        if (next != SoftwareSerial::active_object->_receive_buffer_head) {
+           // save new data in buffer: tail points to where byte goes
+           SoftwareSerial::active_object->_receive_buffer[SoftwareSerial::active_object->_receive_buffer_tail] = rbyte; // save new byte
+           SoftwareSerial::active_object->_receive_buffer_tail = next;
+       //    Serial.print(rbyte);
+        } else {
+           Serial.println("OVERFLOW");
+           SoftwareSerial::active_object->_buffer_overflow = true;
+        }
+       sstate = 0; // ready for next byte
+       PWM1_BLOCK_CONTROL_REG &= (uint32)~PWM1_MASK; // interrupt off.
+     }
+/*           PWM1_COUNTER_REG = (20000 & PWM1_16BIT_MASK);
+            PWM1_PERIOD_REG = (0 & PWM1_16BIT_MASK);
+            PWM1_COMP_CAP_REG = (1001-1 & PWM1_16BIT_MASK);
+            Serial.printf("Start Counter %d period %d\n", (PWM1_COUNTER_REG & PWM1_16BIT_MASK), (PWM1_PERIOD_REG & PWM1_16BIT_MASK)$
+            Serial.printf("Start compare register %d\n", (PWM1_COMP_CAP_REG & PWM1_16BIT_MASK));
+    PWM1_BLOCK_CONTROL_REG |= PWM1_MASK;
+    PWM1_CONTROL_REG |= PWM1_MODE_TIMER_COMPARE;
+    PWM1_CONTROL_REG &= (uint32)~PWM1_UPDOWN_MASK;
+    PWM1_CONTROL_REG |= PWM1_COUNT_DOWN;
+    PWM1_COMMAND_REG = (PWM1_MASK << PWM1_CMD_START);
+    PWM1_BLOCK_CONTROL_REG &= (uint32)~PWM1_MASK;
+} */
+}
+//    Serial.println("Interrupt");
+    CyExitCriticalSection(enableInterrupts);
+}
+
+void SoftwareSerial::setRX(uint8_t rx) {
+  pinMode(rx, INPUT_PULLUP);
+  _receiveBitMask = PIN_TO_BITMASK(rx);
+  _receiveBase = PIN_TO_BASEREG(rx);
+  _receivePin = rx;
+}
+
+void SoftwareSerial::begin(long speed) {
+        PWM1_CONTROL_REG = PWM1_CTRL_TIMER_BASE_CONFIG;
+        
+        /* Set values from customizer to CTRL1 */
+        PWM1_TRIG_CONTROL1_REG  = PWM1_TIMER_SIGNALS_MODES;
+    
+        /* Set values from customizer to INTR */
+        //PWM1_SetInterruptMode(PWM1_TC_INTERRUPT_MASK);
+        // ****** this stopped the interrupt firing at all when set to PWM1_INTR_MASK_CC_MATCH (2)
+	PWM1_INTERRUPT_MASK_REG = PWM1_TC_INTERRUPT_MASK; // orig, 1
+//	PWM1_INTERRUPT_SET_REG = PWM1_INTR_MASK_CC_MATCH;
+        
+        /* Set other values from customizer */
+        PWM1_SetOneShot(0);
+	PWM1_PERIOD_REG = (PWM1_TC_PERIOD_VALUE & PWM1_16BIT_MASK);
+        PWM1_COUNTER_REG = (PWM1_TC_PERIOD_VALUE & PWM1_16BIT_MASK);
+        //PWM1_WritePeriod(PWM1_TC_PERIOD_VALUE );
+
+	PWM1_ISR_StartEx(PWM1_ISR_Interrupt);
+        (* (reg32 *) CYREG_HSIOM_PORT_SEL6)=((* (reg32 *) CYREG_HSIOM_PORT_SEL6)&(~0x00000800u))|0x00000800u;
+
+    uint8 enableInterrupts;
+
+    enableInterrupts = CyEnterCriticalSection();
+    PWM1_COMP_CAP_REG = (1001-1 & PWM1_16BIT_MASK);
+    PWM1_BLOCK_CONTROL_REG |= PWM1_MASK;
+
+    PWM1_CONTROL_REG |= PWM1_MODE_TIMER_COMPARE;
+    PWM1_CONTROL_REG &= (uint32)~PWM1_UPDOWN_MASK;
+    PWM1_CONTROL_REG |= PWM1_COUNT_DOWN;
+    PWM1_COMMAND_REG = (PWM1_MASK << PWM1_CMD_START);
+    CyExitCriticalSection(enableInterrupts);
+
+  setTX(_transmitPin);
+  setRX(_receivePin);
+  // Precalculate the various delays
+  //Calculate the distance between bit in micro seconds
+  uint32_t bit_delay = (uint32_t)(1000000) / (speed);
+
+  _tx_delay = bit_delay;
+Serial.printf("Bit delay for %d is %duS\n", speed, bit_delay);
+
+  //Wait 1/2 bit - 2 micro seconds (time for interrupt to be served)
+  _rx_delay_centering = (bit_delay / 2);
+  //Wait 1 bit - 2 micro seconds (time in each loop iteration)
+  _rx_delay_intrabit = bit_delay;
+  //Wait 1 bit (the stop one)
+  _rx_delay_stopbit = bit_delay;
+
+  listen();
+//  write(0x55); //send a dummy byte to sync the start byte
+}
+
+void SoftwareSerial::end() {
+  stopListening();
+}
+
+uint32 SoftwareSerial::read() {
+  if (!isListening()) {
+    return -1;
+  }
+
+
+  // Empty buffer?
+  if (_receive_buffer_head == _receive_buffer_tail) {
+    return -1;
+  }
+
+  // Read from "head"
+  noInterrupts();
+  uint8_t d = _receive_buffer[_receive_buffer_head]; // grab next byte
+  _receive_buffer_head = (_receive_buffer_head + 1) % _SS_MAX_RX_BUFF;
+  interrupts();
+  return d;
+}
+
+
+int SoftwareSerial::available() {
+  if (!isListening())
+    return 0;
+
+  return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) % _SS_MAX_RX_BUFF;
+}
+
+
+size_t SoftwareSerial::write(uint8_t b) {
+  if (_tx_delay == 0) {
+    setWriteError();
+    return 0;
+  }
+
+  // By declaring these as local variables, the compiler will put them
+  // in registers _before_ disabling interrupts and entering the
+  // critical timing sections below, which makes it a lot easier to
+  // verify the cycle timings
+  bool inv = _inverse_logic;
+  uint16_t delay = _tx_delay;
+
+  if (inv)
+    b = ~b;
+  // turn off interrupts for a clean txmit
+  noInterrupts();
+  // Write the start bit
+  if (inv)
+    DIRECT_WRITE_HIGH(_transmitBase, _transmitBitMask);
+  else
+    DIRECT_WRITE_LOW(_transmitBase, _transmitBitMask);  
+
+  delayMicroseconds(delay);
+
+  // Write each of the 8 bits
+  for (uint8_t i = 0; i < 8; i++) {
+    if (bitRead(b, i)) {
+	DIRECT_WRITE_HIGH(_transmitBase, _transmitBitMask); 
+    }
+    else {
+        DIRECT_WRITE_LOW(_transmitBase, _transmitBitMask);
+    }
+    delayMicroseconds(delay);
+  }
+
+  // restore pin to natural state
+  if (inv)
+    DIRECT_WRITE_LOW(_transmitBase, _transmitBitMask);
+  else
+    DIRECT_WRITE_HIGH(_transmitBase, _transmitBitMask);
+
+  interrupts();
+  delayMicroseconds(delay);
+
+  return 1;
+}
+
+void SoftwareSerial::flush() {
+  if (!isListening())
+    return;
+
+  noInterrupts();
+  _receive_buffer_head = _receive_buffer_tail = 0;
+  interrupts();
+
+}
+
+int SoftwareSerial::peek() {
+  if (!isListening())
+    return -1;
+
+  // Empty buffer?
+  if (_receive_buffer_head == _receive_buffer_tail)
+    return -1;
+
+  // Read from "head"
+  return _receive_buffer[_receive_buffer_head];
+}

--- a/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/SoftwareSerial.h
@@ -1,0 +1,114 @@
+/*
+  This file is part of the ArduinoECCX08 library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef SoftwareSerial_h
+#define SoftwareSerial_h
+
+#include <inttypes.h>
+#include <Stream.h>
+
+/******************************************************************************
+  Definitions
+******************************************************************************/
+#define PIN_IN_PORT(pin)    (pin % PIN_NUMBER_IN_PORT)
+#define PORT_FROM_PIN(pin)  (pin / PIN_NUMBER_IN_PORT)
+#define PORT_OFFSET(port)   (PORT_REG_SHFIT * port)
+#define PORT_ADDRESS(pin)   (CYDEV_GPIO_BASE + PORT_OFFSET(PORT_FROM_PIN(pin)))
+
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          CY_SYS_PINS_READ_PIN(PORT_ADDRESS(pin)+4, PIN_IN_PORT(pin))
+#define DIRECT_WRITE_LOW(base, pin)     CY_SYS_PINS_CLEAR_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_WRITE_HIGH(base, pin)    CY_SYS_PINS_SET_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_MODE_INPUT(base, pin)    CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_DIG_HIZ)
+#define DIRECT_MODE_OUTPUT(base, pin)   CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_STRONG)
+
+
+#define _SS_MAX_RX_BUFF 1024 // RX buffer size
+#ifndef GCC_VERSION
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+
+class SoftwareSerial : public Stream {
+  public:
+    // per object data
+    uint8_t _transmitPin;
+    uint8_t _receivePin;
+    uint32_t  _transmitBase;
+    uint32_t _receiveBase;
+    uint32_t _receiveBitMask;
+    uint32_t _transmitBitMask;
+
+    // Expressed as 4-cycle delays (must never be 0!)
+    uint16_t _rx_delay_centering;
+    uint16_t _rx_delay_intrabit;
+    uint16_t _rx_delay_stopbit;
+    uint16_t _tx_delay;
+
+    uint16_t _buffer_overflow: 1;
+    uint16_t _inverse_logic: 1;
+
+    // static data
+    static char _receive_buffer[_SS_MAX_RX_BUFF];
+    static volatile uint32_t _receive_buffer_tail;
+    static volatile uint32_t _receive_buffer_head;
+    static SoftwareSerial *active_object;
+
+    // private methods
+    void recv() __attribute__((__always_inline__));
+    uint32_t rx_pin_read();
+    void tx_pin_write(uint8_t pin_state) __attribute__((__always_inline__));
+    void setTX(uint8_t transmitPin);
+    void setRX(uint8_t receivePin);
+    void setRxIntMsk(bool enable) __attribute__((__always_inline__));
+
+
+  public:
+    // public methods
+    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
+    ~SoftwareSerial();
+    void begin(long speed);
+    bool listen();
+    void end();
+    bool isListening() {
+      return this == active_object;
+    }
+    bool stopListening();
+    bool overflow() {
+      bool ret = _buffer_overflow;
+      if (ret) _buffer_overflow = false;
+      return ret;
+    }
+    int peek();
+
+    virtual size_t write(uint8_t byte);
+    virtual uint32 read();
+    virtual int available();
+    virtual void flush();
+    operator bool() {
+      return true;
+    }
+
+    using Print::write;
+
+    // public only for easy access by interrupt handlers
+    static inline void handle_interrupt() __attribute__((__always_inline__));
+};
+
+#endif


### PR DESCRIPTION
Use #define's for all port references, add some explanatory comment, and ensure the scheduled packet send uses the DEVPORT port as intended.