### PR TITLE
fix overflow in timedelay variable for 1200 and 2400 baud

### DIFF
--- a/libraries/Basics/src/softSerial.cpp
+++ b/libraries/Basics/src/softSerial.cpp
@@ -1,6 +1,6 @@
 #include "softSerial.h"
 
-uint8_t timedelay = 0;
+uint16_t timedelay = 0;
 uint8_t Recev[8]  ={0};
 uint8_t temp_bin  = 0;
 


### PR DESCRIPTION
With uint8 timedelay variable, the softserial lib was not working with 1200 and 2400 baud for me. After change to uint16, works perfect.