### PR TITLE
Improved Arduino API compliance: dtostrf(), _BV(), radians(), degrees(), sq(), min/max/abs.

### DIFF
--- a/cores/asr650x/Arduino.h
+++ b/cores/asr650x/Arduino.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdlib_noniso.h>
 #include <string.h>
 #include <math.h>
 #include <ASR_Arduino.h>
@@ -54,11 +55,24 @@
 #define  bitSet(value, bit)   ((value) |= (1UL << (bit)))
 #define  bitClear(value, bit)   ((value) &= ~(1UL << (bit)))
 #define  bit(b)   (1 << (b))
+#define  _BV(b)   (1UL << (b))
 
+#ifdef __cplusplus
+#include <algorithm>
+
+using std::abs;
+using std::max;
+using std::min;
+#else
 #define min(a, b) ((a)<(b)?(a):(b))
 #define max(a, b) ((a)>(b)?(a):(b))
 #define abs(x)   ((x)>0?(x):-(x))
+#endif /* __cplusplus */
+
 #define constrain(amt, low, high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#define radians(deg) ((deg)*DEG_TO_RAD)
+#define degrees(rad) ((rad)*RAD_TO_DEG)
+#define sq(x) ((x)*(x))
 #define _min(a,b) ((a)<(b)?(a):(b))
 #define _max(a,b) ((a)>(b)?(a):(b))
 #define noInterrupts() CyGlobalIntDisable


### PR DESCRIPTION
    Hello!

I've made a large multi-platform project build with this Arduino ASR650x Core, there it is: https://github.com/lyusupov/SoftRF/commit/0a8b5c93c89a387210fbdfe7e10e4e9ab4fbca46  ( Travis Ci build log: https://travis-ci.org/github/lyusupov/SoftRF/jobs/679349617 )
and found out that few Arduino API functions are missing.
This PR is an attempt to fix the discrepancy in ASR650x-Arduino master repo.

   Best regards,
   Linar.