### PR TITLE
RST pin GPIO10 does not exists for display

### DIFF
--- a/libraries/OLED/examples/SSD1306_DrawingDemo_I2C/SSD1306_DrawingDemo_I2C.ino
+++ b/libraries/OLED/examples/SSD1306_DrawingDemo_I2C/SSD1306_DrawingDemo_I2C.ino
@@ -1,7 +1,7 @@
 #include <Wire.h>  
 #include "cubecell_SSD1306Wire.h"
 
- SSD1306Wire  display(0x3c, 500000, I2C_NUM_0,GEOMETRY_128_64,GPIO10 ); // addr , freq , i2c group , resolution , rst
+ SSD1306Wire  display(0x3c, 500000, I2C_NUM_0,GEOMETRY_128_64); // addr , freq , i2c group , resolution , rst
 
 
 void drawLines() {


### PR DESCRIPTION
removed GPIO10 on display.init call for SSD1306 I2C