### PR TITLE
Fix: error: 'gpioOn' was not declared in this scope

### DIFF
--- a/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
+++ b/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
@@ -213,7 +213,7 @@ void testRGB(void)
 	turnOnRGB(0,0);
 }
 
-void gpioOn()
+void gpioOn(void)
 {
     pinMode(GPIO0,OUTPUT);
     pinMode(GPIO1,OUTPUT);

--- a/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
+++ b/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
@@ -59,6 +59,8 @@ States_t state;
 bool sleepMode = false;
 int16_t Rssi,rxSize;
 
+
+
 void setup() {
     boardInitMcu( );
     Serial.begin(115200);

--- a/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
+++ b/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
@@ -58,7 +58,21 @@ States_t state;
 bool sleepMode = false;
 int16_t Rssi,rxSize;
 
-
+void gpioOn()
+{
+    pinMode(GPIO0,OUTPUT);
+    pinMode(GPIO1,OUTPUT);
+    pinMode(GPIO2,OUTPUT);
+    pinMode(GPIO3,OUTPUT);
+    pinMode(GPIO4,OUTPUT);
+    pinMode(GPIO5,OUTPUT);
+    digitalWrite(GPIO0,HIGH);
+    digitalWrite(GPIO1,HIGH);
+    digitalWrite(GPIO2,HIGH);
+    digitalWrite(GPIO3,HIGH);
+    digitalWrite(GPIO4,HIGH);    
+    digitalWrite(GPIO5,HIGH);
+}
 
 void setup() {
     boardInitMcu( );
@@ -212,20 +226,4 @@ void testRGB(void)
 		turnOnRGB(i,10);
 	}
 	turnOnRGB(0,0);
-}
-
-void gpioOn(void)
-{
-    pinMode(GPIO0,OUTPUT);
-    pinMode(GPIO1,OUTPUT);
-    pinMode(GPIO2,OUTPUT);
-    pinMode(GPIO3,OUTPUT);
-    pinMode(GPIO4,OUTPUT);
-    pinMode(GPIO5,OUTPUT);
-    digitalWrite(GPIO0,HIGH);
-    digitalWrite(GPIO1,HIGH);
-    digitalWrite(GPIO2,HIGH);
-    digitalWrite(GPIO3,HIGH);
-    digitalWrite(GPIO4,HIGH);    
-    digitalWrite(GPIO5,HIGH);
 }

--- a/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
+++ b/libraries/Basics/examples/Factory_Test_AB01/Factory_Test_AB01.ino
@@ -45,6 +45,7 @@ void OnRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr );
 void displayInof();
 void sleep(void);
 void testRGB(void);
+void gpioOn();
 
 typedef enum
 {
@@ -57,22 +58,6 @@ int16_t txNumber;
 States_t state;
 bool sleepMode = false;
 int16_t Rssi,rxSize;
-
-void gpioOn()
-{
-    pinMode(GPIO0,OUTPUT);
-    pinMode(GPIO1,OUTPUT);
-    pinMode(GPIO2,OUTPUT);
-    pinMode(GPIO3,OUTPUT);
-    pinMode(GPIO4,OUTPUT);
-    pinMode(GPIO5,OUTPUT);
-    digitalWrite(GPIO0,HIGH);
-    digitalWrite(GPIO1,HIGH);
-    digitalWrite(GPIO2,HIGH);
-    digitalWrite(GPIO3,HIGH);
-    digitalWrite(GPIO4,HIGH);    
-    digitalWrite(GPIO5,HIGH);
-}
 
 void setup() {
     boardInitMcu( );
@@ -226,4 +211,20 @@ void testRGB(void)
 		turnOnRGB(i,10);
 	}
 	turnOnRGB(0,0);
+}
+
+void gpioOn()
+{
+    pinMode(GPIO0,OUTPUT);
+    pinMode(GPIO1,OUTPUT);
+    pinMode(GPIO2,OUTPUT);
+    pinMode(GPIO3,OUTPUT);
+    pinMode(GPIO4,OUTPUT);
+    pinMode(GPIO5,OUTPUT);
+    digitalWrite(GPIO0,HIGH);
+    digitalWrite(GPIO1,HIGH);
+    digitalWrite(GPIO2,HIGH);
+    digitalWrite(GPIO3,HIGH);
+    digitalWrite(GPIO4,HIGH);    
+    digitalWrite(GPIO5,HIGH);
 }


### PR DESCRIPTION
Fix "error: 'gpioOn' was not declared in this scope" when using platform.io