### PR TITLE
Update hdc1080measurement.ino

### DIFF
--- a/libraries/SensorBasic/examples/HDC1080/hdc1080measurement/hdc1080measurement.ino
+++ b/libraries/SensorBasic/examples/HDC1080/hdc1080measurement/hdc1080measurement.ino
@@ -11,10 +11,12 @@
  * 
  */
  
-#include <Wire.h>
 #include "HDC1080.h"
 
 HDC1080 hdc1080;
+
+void printTandRH(HDC1080_MeasurementResolution humidity, HDC1080_MeasurementResolution temperature);
+void printRegister(HDC1080_Registers reg);
 
 void setup()
 {


### PR DESCRIPTION
removed (not necessary,):
#include <Wire.h>

declared before setup (platformIO compatibility):

void printTandRH(HDC1080_MeasurementResolution humidity, HDC1080_MeasurementResolution temperature);
void printRegister(HDC1080_Registers reg);