### PR TITLE
Update LoRaSender_ReadBattery.ino

### DIFF
--- a/libraries/LoRa/examples/LoRaBasic/LoRaSender_ReadBattery/LoRaSender_ReadBattery.ino
+++ b/libraries/LoRa/examples/LoRaBasic/LoRaSender_ReadBattery/LoRaSender_ReadBattery.ino
@@ -88,7 +88,7 @@ void setup() {
                                    LORA_PREAMBLE_LENGTH, LORA_FIX_LENGTH_PAYLOAD_ON,
                                    true, 0, 0, LORA_IQ_INVERSION_ON, 3000 );
 
-    state=TX;
+    state=ReadVoltage;
 }
 
 
@@ -135,18 +135,18 @@ void loop()
      default:
           break;
   }
+  Radio.IrqProcess();
 }
 
 void OnTxDone( void )
 {
   Serial.print("TX done!");
   turnOnRGB(0,0);
-  state=TX;
 }
 
 void OnTxTimeout( void )
 {
     Radio.Sleep( );
     Serial.print("TX Timeout......");
-    state=TX;
+    state=ReadVoltage;
 }


### PR DESCRIPTION
Fixes http://community.heltec.cn/t/example-lorasender-readbattery-issue/2603

onTxDone was never called.

The state after TxTimeOut should be ReadVoltage, so you are not re-sending an old value.

The Loop() should be entered with state=ReadVoltage, because your first send is 0 battery, when entering with state TX

After TxDone there is no need to change the state.