### PR TITLE
Add Arduino-standard 'CHANGE' interrupt type definition.

### DIFF
--- a/cores/asr650x/cores/ASR_Arduino.h
+++ b/cores/asr650x/cores/ASR_Arduino.h
@@ -40,10 +40,11 @@ typedef enum
 
 typedef enum
 {
-    NONE,
-    RISING,
-    FALLING,
-    BOTH,
+    NONE=0,
+    RISING=1,
+    FALLING=2,
+    BOTH=3,
+    CHANGE=3
 }IrqModes;
 
 #define DRIVE_MODE_BITS        (3)


### PR DESCRIPTION
The Arduino environment uses rising/falling/CHANGE interrupt types, not rising/falling/BOTH.
This commit defines BOTH and CHANGE to be equivalent.