### PR TITLE
Change software serial time delay data type to prevent overflow <4800 baud

### DIFF
--- a/cores/asr650x/Serial/SoftwareSerial.cpp
+++ b/cores/asr650x/Serial/SoftwareSerial.cpp
@@ -1,7 +1,7 @@
 #include "SoftwareSerial.h"
 
 uint8_t SoftwareSerial::s_currentRx = ~0;
-uint8_t SoftwareSerial::s_timeDelay = 0;
+uint16_t SoftwareSerial::s_timeDelay = 0;
 RingBuffer<uint8_t, 64> SoftwareSerial::s_rxDataBuffer = RingBuffer<uint8_t, 64>();
 bool SoftwareSerial::s_overflow = false;
 

--- a/cores/asr650x/Serial/SoftwareSerial.h
+++ b/cores/asr650x/Serial/SoftwareSerial.h
@@ -49,7 +49,7 @@ private:
 
     static uint8_t s_currentRx;
     static RingBuffer<uint8_t, 64> s_rxDataBuffer;
-    static uint8_t s_timeDelay;
+    static uint16_t s_timeDelay;
     static bool s_overflow;
 
     uint8_t _rxpin;


### PR DESCRIPTION
Current implementation overflows the 8 bit data type. The commit changes it to a 16 bit data type.