### PR TITLE
Fix for setting DR when not using ADR.

### DIFF
--- a/libraries/LoRa/src/LoRaWan_APP.cpp
+++ b/libraries/LoRa/src/LoRaWan_APP.cpp
@@ -42,7 +42,7 @@ int8_t defaultDrForNoAdr = 5;
 #endif
 
 /*loraWan current Dr when adr disabled*/
-int8_t currentDrForNoAdr;
+int8_t currentDrForNoAdr=defaultDrForNoAdr;
 
 /*!
  * User application data size
@@ -665,7 +665,7 @@ void LoRaWanClass::sleep()
 }
 void LoRaWanClass::setDataRateForNoADR(int8_t dataRate)
 {
-	defaultDrForNoAdr = dataRate;
+	currentDrForNoAdr = dataRate;
 }
 
 void LoRaWanClass::ifskipjoin()


### PR DESCRIPTION
I noticed the existing implementation ignored the `LoRaWAN.setDataRateForNoADR` value. This fixes the issue by updating the `currentDrForNoAdr`, which is the one that is actually used. The `defaultDrForNoAdr` value is used to set the default value of the `currentDrForNoAdr`.