### PR TITLE
LoRaWANClass::Send to return indicator that message was accepted

### DIFF
--- a/libraries/LoRa/src/LoRaWan_APP.cpp
+++ b/libraries/LoRa/src/LoRaWan_APP.cpp
@@ -683,7 +683,7 @@ void LoRaWanClass::join()
 	}
 }
 
-void LoRaWanClass::send()
+bool LoRaWanClass::send()
 {
 	if( nextTx == true )
 	{
@@ -698,7 +698,9 @@ void LoRaWanClass::send()
 		}
 		
 		nextTx = SendFrame( );
+		return true;
 	}
+	return false;
 }
 
 void LoRaWanClass::cycle(uint32_t dutyCycle)

--- a/libraries/LoRa/src/LoRaWan_APP.h
+++ b/libraries/LoRa/src/LoRaWan_APP.h
@@ -58,7 +58,7 @@ class LoRaWanClass{
 public:
   void init(DeviceClass_t lorawanClass,LoRaMacRegion_t region);
   void join();
-  void send();
+  bool send();
   void cycle(uint32_t dutyCycle);
   void sleep();
   void setDataRateForNoADR(int8_t dataRate);


### PR DESCRIPTION
The send function would silently drop packets to send if it wasn't ready. This change returns a bool to the application if the
packets was accepted for sending.

This change shouldn't impact any existing code as the function was originally defined as void.